### PR TITLE
added limits.h to resolve MAX_INT on osx

### DIFF
--- a/MBias.c
+++ b/MBias.c
@@ -4,6 +4,7 @@
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <limits.h>
 #include <string.h>
 #include <inttypes.h>
 #include <assert.h>


### PR DESCRIPTION
When building new epi-read methyl dackel 0.4.0, I hit a compilation error on INT_MAX

> MBias.c:157:35: error: use of undeclared identifier 'INT_MAX'
>        bam_mplp_set_maxcnt(iter, INT_MAX);

This was fixed by including limits.h in the header for MBias.c