### PR TITLE
do not recompile on "make test" and "make install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LIBS ?=  # e.g., -L$PREFIX/lib, or where ever htslib is
 LIBBIGWIG ?=
 CFLAGS ?= -Wall -g -O3 -pthread
 
-.PHONY: all clean install version.h
+.PHONY: all clean install
 
 .SUFFIXES:.c .o
 

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -5,7 +5,7 @@ jobs:
 
 - job: 'Linux'
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-latest'
   strategy:
     matrix:
       htslib111:
@@ -14,6 +14,8 @@ jobs:
         htslib_version: '1.12'
       htslib113:
         htslib_version: '1.13'
+      htslib114:
+        htslib_version: '1.14'
     maxParallel: 1
 
   steps:
@@ -35,6 +37,8 @@ jobs:
         htslib_version: '1.12'
       htslib113:
         htslib_version: '1.13'
+      htslib114:
+        htslib_version: '1.14'
     maxParallel: 1
 
   steps:


### PR DESCRIPTION
This patch removes ".PHONY" for version.h.
`.PHONY version.h` causes `make` to not look for the version.h file so
everything that depends on it will be rebuilt on every run of make.
This causes
```
    make LIBBIGWIG=/some/path/libBigWig.a
    make test
```
to fail as `make test` will try to recompile MethylDackel without
LIBBIGWIG set to /some/path/libBigWig.a